### PR TITLE
Fix typos.

### DIFF
--- a/lio/LIO/Core.hs
+++ b/lio/LIO/Core.hs
@@ -41,7 +41,7 @@ throwing an exception, reading data often just increases the current
 label to ensure that @l_r ``canFlowTo`` l_cur@.  This is acomplished
 using a function such as 'taint'.
 
-The second purpose of the current label is to prevent inforation leaks
+The second purpose of the current label is to prevent information leaks
 into public channels. Specifically, it is only permissible to modify
 or write to data labeled @l_w@ when @l_cur``canFlowTo`` l_w@. Thus,
 the following attempt to leak the @val@ after reading it from a secret

--- a/lio/LIO/Label.hs
+++ b/lio/LIO/Label.hs
@@ -46,7 +46,7 @@ objects the thread will be allowed to modify.  Hence, after a thread
 with current label @lcur@ observes data labeled @l1@, it must hold
 that @l1 ``canFlowTo`` lcur@.  If the thread is later permitted to
 modify an object labeled @l2@, it must hold that @lcur ``canFlowTo``
-l2@.  By transitifity of the ``canFlowTo`` relation, it holds that @l1
+l2@.  By transitivity of the ``canFlowTo`` relation, it holds that @l1
 ``canFlowTo`` l2@.
 
 -}


### PR DESCRIPTION
Fixed two small typos in documentation written in {Core|Label}.hs files.